### PR TITLE
Added titles to calendar headers with full day names

### DIFF
--- a/calendar/calendar.html
+++ b/calendar/calendar.html
@@ -22,13 +22,13 @@
             <div class="right" onclick="nextMonth()"></div>
             <table border="1">
                 <thead class="center-headers">
-                    <th>S</th>
-                    <th>M</th>
-                    <th>T</th>
-                    <th>W</th>
-                    <th>T</th>
-                    <th>F</th>
-                    <th>S</th>
+                    <th title="Sunday">S</th>
+                    <th title="Monday">M</th>
+                    <th title="Tuesday">T</th>
+                    <th title="Wednesday">W</th>
+                    <th title="Thursday">T</th>
+                    <th title="Friday">F</th>
+                    <th title="Saturday">S</th>
                 </thead>
                 <tbody id="monthCalendar">
                 </tbody>


### PR DESCRIPTION
Add hover text to the S-M-T-W-T-F-S indicating the full day of week. It doesn't hurt the UX, and can help potentially more quickly clear up any minor confusion. That said it is a minor tweak.